### PR TITLE
Item is null when item.GetType() is called and would through a NullReferenceException.

### DIFF
--- a/CrmFluentExtensions/CrmFluentExtensions/FluentChainAction.cs
+++ b/CrmFluentExtensions/CrmFluentExtensions/FluentChainAction.cs
@@ -290,9 +290,10 @@ namespace CrmFluentExtensions
                 for (var i = 0; i < values.Length; i++)
                 {
                     var item = values[i];
-                    if (item == null) throw new ArgumentNullException(
-                        string.Format("Parameter of Type {0} at index {1} is null", item.GetType(), i)
-                        );
+                    if (item == null)
+                    {
+                        throw new ArgumentNullException(string.Format("Parameter at index {0} is null", i));
+                    }
                 }
 
                 action();
@@ -314,11 +315,8 @@ namespace CrmFluentExtensions
                     var item = values[i];
                     if (item == null || item.Equals(default(T)))
                     {
-                        throw new ArgumentNullException(
-                        string.Format("Parameter of Type {0} at index {1} is null or default", item.GetType(), i)
-                        );
+                        throw new ArgumentNullException(string.Format("Parameter at index {0} is null or default", i));
                     }
-
                 }
 
                 action();

--- a/CrmFluentExtensions/CrmFluentExtensions/FluentChainActionWithReturn.cs
+++ b/CrmFluentExtensions/CrmFluentExtensions/FluentChainActionWithReturn.cs
@@ -380,9 +380,10 @@ namespace CrmFluentExtensions
                 for (var i = 0; i < values.Length; i++)
                 {
                     var item = values[i];
-                    if (item == null) throw new ArgumentNullException(
-                        string.Format("Parameter of Type {0} at index {1} is null", item.GetType(), i)
-                        );
+                    if (item == null)
+                    {
+                        throw new ArgumentNullException(string.Format("Parameter at index {0} is null", i));
+                    }
                 }
 
                 return action();
@@ -404,11 +405,8 @@ namespace CrmFluentExtensions
                     var item = values[i];
                     if (item == null || item.Equals(default(T)))
                     {
-                        throw new ArgumentNullException(
-                        string.Format("Parameter of Type {0} at index {1} is null or default", item.GetType(), i)
-                        );
+                        throw new ArgumentNullException(string.Format("Parameter at index {0} is null or default", i));
                     }
-
                 }
 
                 return action();


### PR DESCRIPTION
When trying to throw an ArgumentNullException it would actually fail to throw the intended exception and through a NullReferenceException.

Removed code that would make it fail which meant changing the exception message always.
